### PR TITLE
Add support for prefixes and restore support for full years

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # daily-version [![Build Status](https://travis-ci.org/fregante/daily-version.svg?branch=master)](https://travis-ci.org/fregante/daily-version)
 
-> Get the current date formatted as a version. Automatically add the time if there's already a git tag for today's version.
+> Get the current date formatted as a version. Automatically add the time if there’s already a git tag for today’s version.
 
 `daily-version` can be used to version your daily/nightly builds while still allowing multiple versions each day.
 
@@ -23,36 +23,39 @@ $ git tag $(daily-version)
 $ daily-version
 17.8.29.1451
 # Detects the existing tag, and includes generates a sub-version based on the hours/seconds
+
+$ daily-version v
+v17.8.29.1451
+# Lets you specify any prefix
 ```
 
-### Travis
+### GitHub Actions
 
-For example, it can be used to set the version of a Web Extension in a Travis cronjob:
+[This workflow](https://github.com/notlmn/browser-extension-template/blob/master/.github/workflows/deploy-automatic.yml) will create a new tag automatically, daily, using `daily-version`
 
 ```yml
-# travis.yml
-deploy:
-  provider: script
-  script: npm run update-version && npm run upload
-  on:
-    condition: $TRAVIS_EVENT_TYPE = cron
+# If new commits are available since the last tag, create a new version/tag
+# - Every day at 15:15
+
+name: Auto-tagger
+
+on:
+  schedule:
+    - cron: '15 15 * * *'
+
+jobs:
+  create-version:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: fregante/setup-git-token@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - run:
+          git push --delete origin deploy
+          if [[ $(git tag -l --points-at HEAD) = "" ]]; then
+            export VER=$(npx daily-version)
+            git tag $VER -m $VER
+            git push origin $VER
+          fi
 ```
-
-```js
-// package.json
-{
-    "scripts": {
-        // https://github.com/maikelvl/dot-json
-        "update-version": "dot-json manifest.json version $(daily-version)"
-
-        // https://github.com/DrewML/chrome-webstore-upload-cli/
-        "upload": "webstore upload --auto-publish"
-    }
-}
-```
-
-
-## License
-
-MIT © [Federico Brigante](https://bfred.it)
-

--- a/index.sh
+++ b/index.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
 
-HEAD=$1
-TODAY=$(utc-version --short)
+PREFIX=$1
+TODAY=$(npx utc-version --short)
 
 # Check if there's already a tag for today
-if [ "$(git tag -l "$HEAD$TODAY")" ]; then
-	echo "$HEAD$(utc-version)"
+if [ "$(git tag -l "$PREFIX$TODAY")" ]; then
+	echo "$PREFIX$(npx utc-version)"
 else
-	echo "$TODAY"
+	echo "$PREFIX$TODAY"
 fi

--- a/index.sh
+++ b/index.sh
@@ -1,12 +1,11 @@
-#! /bin/bash
+#!/bin/bash
 
-YEAR=${1:-y}
-CURR=$(date -u +%"$YEAR".%-m.%-d)
+HEAD=$1
+TODAY=$(utc-version --short)
 
 # Check if there's already a tag for today
-if [ "$(git tag -l "$CURR")" ]; then
-	utc-version
+if [ "$(git tag -l "$HEAD$TODAY")" ]; then
+	echo "$HEAD$(utc-version)"
 else
-	echo "$CURR"
+	echo "$TODAY"
 fi
-

--- a/package.json
+++ b/package.json
@@ -2,7 +2,14 @@
   "name": "daily-version",
   "version": "0.12.0",
   "description": "Get the current date formatted as a version. Automatically add the time if you already released a version today.",
-  "keywords": [],
+  "keywords": [
+    "version",
+    "release",
+    "year",
+    "time",
+    "tag",
+    "git"
+  ],
   "repository": "fregante/daily-version",
   "license": "MIT",
   "author": "Federico Brigante <opensource@bfred.it> (bfred.it)",
@@ -14,6 +21,6 @@
     "test": "shellcheck index.sh"
   },
   "dependencies": {
-    "utc-version": "1.1.0"
+    "utc-version": "^2.0.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -13,10 +13,10 @@
   "repository": "fregante/daily-version",
   "license": "MIT",
   "author": "Federico Brigante <opensource@bfred.it> (bfred.it)",
+  "bin": "index.sh",
   "files": [
     "index.sh"
   ],
-  "bin": "index.sh",
   "scripts": {
     "test": "shellcheck index.sh"
   },


### PR DESCRIPTION
- "2020.10.5", with `daily-version 20`
- "v20.10.5", with `daily-version v`